### PR TITLE
Fixes #18: wrong generated names for 'remainder' sets

### DIFF
--- a/electrum/src/main/java/edu/mit/csail/sdg/alloy4compiler/translator/BoundsComputer.java
+++ b/electrum/src/main/java/edu/mit/csail/sdg/alloy4compiler/translator/BoundsComputer.java
@@ -140,7 +140,7 @@ final class BoundsComputer {
               lower.removeAll(childTS);
               upper.removeAll(childTS);
            }
-            Expression relation = sol.addRel(sig.label+" remainder", lower, upper, sig);
+            Expression relation = sol.addRel(sig.label + "_remainder", lower, upper, sig);
             sum = sum.union(relation);
         }
         if (sig.isOne != null) // [HASLab]


### PR DESCRIPTION
Replaced a leading space by an underscore.